### PR TITLE
BUG fix: Create menu should open modal if no preferences selected

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -59,7 +59,7 @@ function initApp() {
     }  
 }
 
-$(document).on("click", ".pref-btn", function () {
+function getPrefs () {
     proteinDiv.empty();
     healthDiv.empty();
     dietDiv.empty();
@@ -129,7 +129,7 @@ $(document).on("click", ".pref-btn", function () {
         label.append(activities[i]);
         label.append($("<br>"));
     }
-});
+};
 
 
 function createMenuFramework() {
@@ -271,10 +271,12 @@ $("#open").on("click", function () {
 
 $(".save-prefs").on("click", retrieveData);
 
-$(".menu-update").on("click", function () {
-    searchEdamam();
-    searchActivity();
+$(document).on("click", ".menu-update", function () {
+        searchEdamam();
+        searchActivity();
 });
+
+$(document).on("click", ".pref-btn", getPrefs);
 
 $(".favorite-btn").on("click", saveFavorites);
 

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
     </div>
 
     <div id="weekdisplay">
-        <button class="uk-button uk-button-default uk-align-center uk-width-1-2 menu-update">Create my menu</button>
+        <button class="uk-button uk-button-default uk-align-center uk-width-1-2 pref-btn" uk-toggle="target: #preference-modal">Create my menu</button>
         <!-- This is the display area for the days -->
     </div>
 

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
             <h2 class="uk-modal-title">Select Your Dietary Preferences</h2>
 
             <div class="modal-list">
-                <h5 class="uk-heading-line uk-text-center"><span>Select protein preferences</span></h5>
+                <h5 class="uk-heading-line uk-text-center"><span>Select protein preferences (required)</span></h5>
 
                 <div class="uk-margin">
                     <div class="uk-form-controls uk-column-1-3 protein">
@@ -84,7 +84,7 @@
             </div>
 
             <div class="modal-list">
-                <h5 class="uk-heading-line uk-text-center"><span>Describe your diet</span></h5>
+                <h5 class="uk-heading-line uk-text-center"><span>Describe your diet (optional)</span></h5>
 
                 <div class="uk-margin">
                     <div class="uk-form-controls uk-column-1-3 diet-preference">
@@ -94,7 +94,7 @@
             </div>
 
             <div class=" modal-list">
-                <h5 class="uk-heading-line uk-text-center"><span>Select any dietary restrictions</span></h5>
+                <h5 class="uk-heading-line uk-text-center"><span>Select any dietary restrictions (optional)</span></h5>
 
                 <div class="uk-margin">
                     <div class="uk-form-controls uk-column-1-3 health-preference">
@@ -104,7 +104,7 @@
             </div>
 
             <div class=" modal-list">
-                <h5 class="uk-heading-line uk-text-center"><span>Select preferred dinnertime activities</span></h5>
+                <h5 class="uk-heading-line uk-text-center"><span>Select preferred dinnertime activities (required)</span></h5>
 
                 <div class="uk-margin">
                     <div class="uk-form-controls uk-column-1-3 activity-preference">


### PR DESCRIPTION
Just a quick fix to have the create menu button toggle the preferences modal if there are no preferences already selected.

This was a simple fix because the search functions actually empty the `weekdisplay` div and replace the create menu button with the refresh menu button. So I changed the behavior of the create menu button to behave more like the preferences and get started button.  